### PR TITLE
Hotfix to connector logic

### DIFF
--- a/DB/connectors/abstract/SQL/sql_connector.py
+++ b/DB/connectors/abstract/SQL/sql_connector.py
@@ -9,8 +9,8 @@ class SQLConnector(BaseModel):
     user: str
     password: str
     database: str
-    _connection: object
-    _cursor: object
+    connection: object
+    cursor: object
 
     def __enter__(self):
         self.connect()

--- a/DB/connectors/solid/SQL/mysql_connector.py
+++ b/DB/connectors/solid/SQL/mysql_connector.py
@@ -6,24 +6,24 @@ from DB.connectors.abstract.SQL.sql_connector import SQLConnector
 class MySqlConnector(SQLConnector):
 
     def connect(self):
-        self._connection = mysql.connector.connect(
+        self.connection = mysql.connector.connect(
             host=self.host,
             port=self.port,
             database=self.database,
             user=self.user,
             password=self.password
         )
-        self._cursor = self._connection.cursor()
+        self.cursor = self.connection.cursor()
 
     def disconnect(self):
-        self._cursor.close()
-        self._connection.close()
+        self.cursor.close()
+        self.connection.close()
 
     def execute(self, query: str):
-        self._cursor.execute(query)
+        self.cursor.execute(query)
 
     def fetch(self, query: str):
-        return self._cursor.fetchall()
+        return self.cursor.fetchall()
 
     def commit(self):
-        self._connection.commit()
+        self.connection.commit()

--- a/DB/connectors/solid/SQL/postgre_sql_connector.py
+++ b/DB/connectors/solid/SQL/postgre_sql_connector.py
@@ -6,24 +6,25 @@ from DB.connectors.abstract.SQL.sql_connector import SQLConnector
 class PostgreSqlConnector(SQLConnector):
 
     def connect(self):
-        self._connection: psycopg2.connection = psycopg2.connect(
+        self.connection: psycopg2.connection = psycopg2.connect(
             host=self.host,
             port=self.port,
             database=self.database,
             user=self.user,
             password=self.password
         )
-        self._cursor: psycopg2.cursor = self._connection.cursor()
+        self.cursor: psycopg2.cursor = self.connection.cursor()
 
     def disconnect(self):
-        self._cursor.close()
-        self._connection.close()
+        self.cursor.close()
+        self.connection.close()
 
     def execute(self, query: str):
-        self._cursor.execute(query)
+        self.cursor.execute(query)
 
     def fetch(self, query: str):
-        return self._cursor.fetchall()
+        self.execute(query)
+        return self.cursor.fetchall()
 
     def commit(self):
-        self._connection.commit()
+        self.connection.commit()

--- a/test_connector.py
+++ b/test_connector.py
@@ -13,7 +13,8 @@ def test_connector():
         engine_name=config_data.get('db').get('engine')
     )
     sql_connector = connector_factory.get_sql_connector()
-    print(sql_connector.execute('SELECT * FROM tasks;'))
+    with sql_connector:
+        sql_connector.fetch('SELECT * FROM tasks;')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- cursor and connector being private caused problems with the pydantic. Removed the private notation from them.
- execute had a bug, fixed it with combining it with fetch method.
- test script was missing its context manager. Saw it after deploy.